### PR TITLE
Handshake

### DIFF
--- a/publish/background/service-worker.js
+++ b/publish/background/service-worker.js
@@ -23,12 +23,10 @@ chrome.runtime.onMessage.addListener((message) => {
     case 'side-panel-dom-loaded':
       isSidePanelReady = true
       dpr = message.dpr
-      console.log('Service worker: Side panel is now ready.')
       if (resolveSidePanelPromise) {
         resolveSidePanelPromise() // Resolve the existing promise when the side panel is ready
       }
-      // Start listening
-      toggleWebRequestListener(true)
+      console.log('Service worker: Side panel is now ready.')
       break
 
     case 'reset-emissions':
@@ -37,7 +35,7 @@ chrome.runtime.onMessage.addListener((message) => {
 
     case 'panel-closed':
       isSidePanelReady = false
-      toggleWebRequestListener(true)
+      toggleWebRequestListener(false)
       // Create a new Promise that will resolve when the side panel is ready again
       sidePanelReadyPromise = new Promise((resolve) => {
         resolveSidePanelPromise = resolve
@@ -201,12 +199,14 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tabs) => {
     })
     console.log('The URL changed')
     clearNetworkTraffic()
-  } else if (changeInfo?.status === 'loading') {
+  } else if (changeInfo?.status === 'loading' && isSidePanelReady) {
     chrome.runtime.sendMessage({
       action: 'url-reloaded',
       url: tabs.url,
       tabId,
     })
+    // Start listening
+    toggleWebRequestListener(true)
     console.log('The URL was reloaded (page refresh)')
   }
 })

--- a/publish/background/service-worker.js
+++ b/publish/background/service-worker.js
@@ -18,6 +18,7 @@ let sidePanelReadyPromise = new Promise((resolve) => {
 
 // Only add this listener **once**
 chrome.runtime.onMessage.addListener((message) => {
+  console.log('Message')
   switch (message.type) {
     case 'side-panel-dom-loaded':
       isSidePanelReady = true
@@ -26,25 +27,22 @@ chrome.runtime.onMessage.addListener((message) => {
       if (resolveSidePanelPromise) {
         resolveSidePanelPromise() // Resolve the existing promise when the side panel is ready
       }
-      break
-
-    case 'panel-visibility':
-      // Enable (add), or disable (remove) the web request listener
-      toggleWebRequestListener(message.isOpen)
+      // Start listening
+      toggleWebRequestListener(true)
       break
 
     case 'reset-emissions':
       clearNetworkTraffic()
       break
 
-    case 'sidepanel-closed':
+    case 'panel-closed':
       isSidePanelReady = false
-      console.log('Service worker: Side panel is closed.')
-
+      toggleWebRequestListener(true)
       // Create a new Promise that will resolve when the side panel is ready again
       sidePanelReadyPromise = new Promise((resolve) => {
         resolveSidePanelPromise = resolve
       })
+      console.log('Service worker: Side panel is closed.')
       break
 
     default:
@@ -214,7 +212,7 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tabs) => {
 })
 
 // When the visitor moves to a different, open tab, we clear the db
-// And send a message to the side panel so that the display can be reset
+// And disable the side panel
 chrome.tabs.onActivated.addListener(async (activeInfo) => {
   console.log('Tab switched. New active tab ID:', activeInfo.tabId)
   chrome.sidePanel.setOptions({ enabled: false })

--- a/publish/side_panel/side-panel.js
+++ b/publish/side_panel/side-panel.js
@@ -11,14 +11,12 @@ import {
   toggleNotification,
 } from '../background/utils.js'
 
-document.addEventListener('visibilitychange', () => {
-  // This event will fire when the side panel is opened (!hidden)
-  // This event will fire when the side panel is closed or another tab takes focus (hidden)
-  if (document.hidden) {
-    chrome.runtime.sendMessage({ type: 'panel-visibility', isOpen: false })
-  } else {
-    chrome.runtime.sendMessage({ type: 'panel-visibility', isOpen: true })
-  }
+// Optionally, you can also add an unload event to detect when the panel is closed
+window.addEventListener('unload', function () {
+  chrome.runtime.sendMessage({
+    type: 'panel-closed',
+    isOpen: false, // Panel is closed
+  })
 })
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/publish/side_panel/side-panel.js
+++ b/publish/side_panel/side-panel.js
@@ -190,12 +190,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // We need to reset the display in these 3 scenarios
   // The service worker db is cleared before any of these messages is received by the side panel
-  chrome.runtime.onMessage.addListener((message) => {
-    // If the visitors goes elsewhere, close the side panel
-    if (message.action === 'tab-switched') {
-      window.close()
-    }
-
+  chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (message.action === 'url-changed' || message.action === 'url-reloaded') {
       resetPanelDisplay()
       if (message.url !== url) {

--- a/publish/side_panel/side-panel.js
+++ b/publish/side_panel/side-panel.js
@@ -12,7 +12,7 @@ import {
 } from '../background/utils.js'
 
 // Optionally, you can also add an unload event to detect when the panel is closed
-window.addEventListener('unload', function () {
+document.addEventListener('unload', function () {
   chrome.runtime.sendMessage({
     type: 'panel-closed',
     isOpen: false, // Panel is closed
@@ -188,7 +188,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // We need to reset the display in these 3 scenarios
   // The service worker db is cleared before any of these messages is received by the side panel
-  chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  chrome.runtime.onMessage.addListener((message) => {
     if (message.action === 'url-changed' || message.action === 'url-reloaded') {
       resetPanelDisplay()
       if (message.url !== url) {


### PR DESCRIPTION
I think the main issue was that it wasn't possible for the side panel to tell the service worker when it was open again. When switching tabs, since the side panel isn't global (it has a `tabId` option), I believe it wasn't able to send messages anymore. But honnestly it's still not entirely clear how this work.
So instead I switched the side panel visibility management entirely to the service worker itself since it's always on. 
I'm pushing this as it is, it works on my side but I haven't tried to be naughty and break it. 

Let me know what you think as I had to somewhat change the logic you had in place 