### PR TITLE
handle panel state in sw and remove redundant handleWebRequest

### DIFF
--- a/publish/background/service-worker.js
+++ b/publish/background/service-worker.js
@@ -25,12 +25,27 @@ const getCurrentTab = async () => {
 }
 
 chrome.runtime.onInstalled.addListener(() => {
-  // Open the panel when the visitor clicks on the extension icon
-  chrome.action.onClicked.addListener((tab) => {
-    console.log('User clicked on extension icon')
-    toggleWebRequestListener(true)
-    chrome.sidePanel.open({ tabId: tab.id })
+  console.log('Extension installed')
+})
+
+let isSidePanelOpen = false
+
+const closeSidePanel = () => {
+  isSidePanelOpen = !isSidePanelOpen
+  chrome.runtime.sendMessage({
+    action: 'close-side-panel',
   })
+  console.log('isSidePanelOpen: ', isSidePanelOpen)
+}
+
+chrome.action.onClicked.addListener((tab) => {
+  toggleWebRequestListener(!isSidePanelOpen)
+  if (!isSidePanelOpen) {
+    chrome.sidePanel.open({ windowId: tab.windowId })
+    isSidePanelOpen = !isSidePanelOpen
+  } else {
+    closeSidePanel()
+  }
 })
 
 // Update network traffic
@@ -189,9 +204,6 @@ chrome.tabs.onActivated.addListener(async (activeInfo) => {
   // Fetch details of the new active tab
   chrome.tabs.get(activeInfo.tabId, (tab) => {
     console.log('New active tab URL:', tab.url)
-    // Send message to side panel
-    chrome.runtime.sendMessage({
-      action: 'tab-switched',
-    })
+    closeSidePanel()
   })
 })

--- a/publish/side_panel/side-panel.js
+++ b/publish/side_panel/side-panel.js
@@ -182,7 +182,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // The service worker db is cleared before any of these messages is received by the side panel
   chrome.runtime.onMessage.addListener((message) => {
     // If the visitors goes elsewhere, close the side panel
-    if (message.action === 'tab-switched') {
+    if (message.action === 'close-side-panel') {
       window.close()
     }
 


### PR DESCRIPTION
In this version panel state (visible/hidden) is handled in the service worker

- Removed unnecessary handleWebRequest
- Moved chrome.action.onClicked.addListener inside onInstalled event to make sure it fires
- Enable/disable web request listener depending on whether the user has clicked on the icon (enabled), or navigated to a different tab (disabled)